### PR TITLE
Expose Next Game DateTime as Attribute

### DIFF
--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -125,7 +125,7 @@ class NHLSensor(Entity):
             dttm = dt.strptime(dates['next_game_datetime'],
                                '%Y-%m-%dT%H:%M:%S%z')
             dttm_local = dt_util.as_local(dttm)
-            time = {'next_game_time': dttm_local.strftime('%-I:%M %p')}
+            time = {'next_game_time': dttm_local.strftime('%-I:%M %p'), 'next_game_datetime': dttm_local}
             # If next game is scheduled Today or Tomorrow,
             # return "Today" or "Tomorrow". Else, return
             # the actual date of the next game.


### PR DESCRIPTION
This adds a new attribute, "Next game datetime," which exposes the date and time of the next game in a single attribute. This is necessary if you want to have automations that rely on the start time. 

Probably not being defined in the best place; maybe there's a better place for it to be placed?